### PR TITLE
Flip boolean operation

### DIFF
--- a/src/wasm/include/web-ifc-geometry.h
+++ b/src/wasm/include/web-ifc-geometry.h
@@ -378,7 +378,7 @@ namespace webifc
 					}
 					else
 					{
-						resultMesh = boolSubtract_CSGJSCPP(flatFirstMesh, flatSecondMesh);
+						resultMesh = boolSubtract_CSGJSCPP(flatSecondMesh, flatFirstMesh);
 					}
 
 					if (_loader.GetSettings().DUMP_CSG_MESHES)


### PR DESCRIPTION
Boolean operations on non FAST_BOOL web-ifc seem inverted. Using FAST_BOOL = TRUE the operation went ok, but the shape is invalid.

I tried to create a test file, but did not succeed. Because of NDAs I cannot pass my IFC source.