### PR TITLE
Added module field in package.json to separate cjs and esm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-ifc",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "web-ifc",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "devDependencies": {
         "@types/jest": "^27.0.3",
         "@types/three": "^0.130.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "web-ifc",
   "version": "0.0.30",
   "description": "ifc loading on the web",
-  "main": "web-ifc-api.js",
+  "main": "web-ifc-api-node.js",
+  "module": "web-ifc-api.js",
   "watch": {
     "build-viewer": {
       "patterns": [


### PR DESCRIPTION
According to the [node.js document](https://nodejs.org/api/packages.html#dual-commonjses-module-packages), the `"main"` field should be specifying the `cjs` entry point and the `"module"` field should be used for the `esm` entry point.
