### PR TITLE
Build non-module javascript api that can be used as a traditional javascript file

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
         "./src"
       ],
       "extensions": "ts"
+    },
+    "build-web-ifc-api-browser": {
+      "patterns": [
+        "./src"
+      ],
+      "extensions": "ts"
     }
   },
   "pckg-gui": {},
@@ -28,9 +34,10 @@
     "build-wasm-debug": "em++ --bind -O3 -gsource-map -std=c++17 --source-map-base http://localhost:5000/web-ifc-js/wasm-lib/ -flto -fno-exceptions./src/wasm/web-ifc-api.cpp -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s ASSERTIONS=1 -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=WebIFCWasm -s MODULARIZE=1 -s EXPORTED_RUNTIME_METHODS=[\"FS\"] -O3 -o dist/web-ifc.js",
     "build-wasm-release": "em++ --bind -O3 -std=c++17 -flto --define-macro=REAL_T_IS_DOUBLE -I ./src/wasm/deps/godot-csg/  -I ./src/wasm/deps/godot-csg/platform/javascript/ ./src/wasm/web-ifc-api.cpp  ./src/wasm/deps/godot-csg/csg.cpp ./src/wasm/deps/godot-csg/core/math/aabb.cpp ./src/wasm/deps/godot-csg/core/math/basis.cpp ./src/wasm/deps/godot-csg/core/math/math_funcs.cpp ./src/wasm/deps/godot-csg/core/os/memory.cpp ./src/wasm/deps/godot-csg/core/os/mutex.cpp ./src/wasm/deps/godot-csg/thirdparty/misc/pcg.cpp ./src/wasm/deps/godot-csg/core/math/plane.cpp ./src/wasm/deps/godot-csg/core/math/quaternion.cpp ./src/wasm/deps/godot-csg/core/math/random_pcg.cpp ./src/wasm/deps/godot-csg/core/math/transform_3d.cpp ./src/wasm/deps/godot-csg/core/math/vector2.cpp ./src/wasm/deps/godot-csg/core/math/vector3.cpp -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=WebIFCWasm -s MODULARIZE=1 -s USE_PTHREADS=0 -s EXPORTED_RUNTIME_METHODS=[\"FS\"] -O3 -o dist/web-ifc.js",
     "build-wasm-release-mt": "em++ --bind -O3 -std=c++17 -flto --define-macro=REAL_T_IS_DOUBLE -I ./src/wasm/deps/godot-csg/  -I ./src/wasm/deps/godot-csg/platform/javascript/ ./src/wasm/web-ifc-api.cpp  ./src/wasm/deps/godot-csg/csg.cpp ./src/wasm/deps/godot-csg/core/math/aabb.cpp ./src/wasm/deps/godot-csg/core/math/basis.cpp ./src/wasm/deps/godot-csg/core/math/math_funcs.cpp ./src/wasm/deps/godot-csg/core/os/memory.cpp ./src/wasm/deps/godot-csg/core/os/mutex.cpp ./src/wasm/deps/godot-csg/thirdparty/misc/pcg.cpp ./src/wasm/deps/godot-csg/core/math/plane.cpp ./src/wasm/deps/godot-csg/core/math/quaternion.cpp ./src/wasm/deps/godot-csg/core/math/random_pcg.cpp ./src/wasm/deps/godot-csg/core/math/transform_3d.cpp ./src/wasm/deps/godot-csg/core/math/vector2.cpp ./src/wasm/deps/godot-csg/core/math/vector3.cpp -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=WebIFCWasm -s MODULARIZE=1 -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=navigator.hardwareConcurrency -s EXPORTED_RUNTIME_METHODS=[\"FS\"] -O3 -o dist/web-ifc-mt.js",
-    "build-api": "cpy src/*.ts dist && cpy src/helpers/*.ts dist/helpers && npm run build-ts-api && npm run build-web-ifc-api-mjs && npm run build-web-ifc-api-node && npm run copy-to-dist",
+    "build-api": "cpy src/*.ts dist && cpy src/helpers/*.ts dist/helpers && npm run build-ts-api && npm run build-web-ifc-api-mjs && npm run build-web-ifc-api-browser && npm run build-web-ifc-api-node && npm run copy-to-dist",
     "build-ts-api": "tsc --emitDeclarationOnly && cpy dist/web-ifc-api.d.ts dist && cpy dist/web-ifc-api.d.ts dist --rename=web-ifc-api-node.d.ts",
     "build-web-ifc-api-mjs": "esbuild dist/web-ifc-api.ts --bundle --format=esm --external:path --external:fs --external:perf_hooks --outfile=./dist/web-ifc-api.js",
+    "build-web-ifc-api-browser": "esbuild dist/web-ifc-api.ts --bundle --format=iife --global-name=WebIFC --external:path --external:fs --external:perf_hooks --outfile=./dist/web-ifc-api-browser.js",
     "build-web-ifc-api-node": "esbuild dist/web-ifc-api.ts --bundle --platform=node --outfile=./dist/web-ifc-api-node.js",
     "copy-to-dist": "cpy README.md dist && cpy package.json dist && cpy src/ifc2x4.ts dist",
     "build-viewer": "npm run bundle-viewer && npm run copy-wasm-viewer",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "web-ifc-api-node.js",
     "web-ifc-api-node.d.ts",
     "web-ifc-api.js",
+	"web-ifc-api-browser.js",
     "web-ifc-api.d.ts",
     "ifc2x4.d.ts",
     "ifc2x4_helper.d.ts"


### PR DESCRIPTION
I've added a build step that generates the library as a non-module javascript file, so you can use it in the traditional way (no modules).

HTML:
```html
<script type="text/javascript" src="web-ifc-api-browser.js"></script>
```

JavaScript:
```js
let ifcAPI = new WebIFC.IfcAPI ();
// do the job
```