### PR TITLE
Typo fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See [examples](https://github.com/tomvandig/web-ifc/tree/main/examples/usage/src
 
 ### Setting up emscripten
 
-The WASM library is built through emscripten, please see [the emscripten installation guide](https://emscripten.org/docs/getting_started/downloads.html) for information on how to set up emscripten. Afterwards both `setup-env` and `em++` need to be in your path.
+The WASM library is built through emscripten, please see [the emscripten installation guide](https://emscripten.org/docs/getting_started/downloads.html) for information on how to set up emscripten. Afterwards `emsdk_env` needs to be in your path.
 
 ### WASM library
 


### PR DESCRIPTION
Only `emsdk_env` should be in the path, `em++` will be added automatically after running `npm run setup-env`.